### PR TITLE
Fix 'Response object is too long.' in case of CloudFormation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ boto3
 mysql-connector-python
 requests
 jsonschema
-cfn_resource_provider
+cfn_resource_provider>==0.10.5


### PR DESCRIPTION
Seems like an issue similar to its [Postgres counterpart](https://github.com/binxio/cfn-postgresql-user-provider/issues/2). I was assuming the root cause and [fix](https://github.com/binxio/cfn-postgresql-user-provider/commit/3f079ca39316628c3b814d7f9fc9035a0efecaf4) would also be similar.

However, trying to test this PR out I can't seem to pull the right version still when redeploying...
I guess I must be missing something. Placing this PR here hoping to get some help @mvanholsteijn  :)