### PR TITLE
Fail if Custom Resource can't connect to Database

### DIFF
--- a/src/mysql_user_provider.py
+++ b/src/mysql_user_provider.py
@@ -8,6 +8,7 @@ from hashlib import sha1
 import mysql.connector
 from botocore.exceptions import ClientError
 from cfn_resource_provider import ResourceProvider
+from mysql.connector import Error
 
 log = logging.getLogger()
 log.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -213,8 +214,11 @@ class MySQLUser(ResourceProvider):
         log.info('connecting to database %s on port %d as user %s', self.host, self.port, self.dbowner)
         try:
             self.connection = mysql.connector.connect(**self.connect_info)
-        except Exception as e:
-            raise ValueError('Failed to connect, %s' % e)
+            if self.connection.is_connected():
+                print("Connected to MySQL database.")
+        except Error as e:
+            print("Error while connecting to MySQL", e)
+            raise ValueError('"Error while connecting to MySQL {}'.format(e))
 
     def close(self):
         if self.connection:

--- a/src/mysql_user_provider.py
+++ b/src/mysql_user_provider.py
@@ -195,7 +195,8 @@ class MySQLUser(ResourceProvider):
     @property
     def connect_info(self):
         return {'host': self.host, 'port': self.port, 'database': self.dbname,
-                'user': self.dbowner, 'password': self.dbowner_password}
+                'user': self.dbowner, 'password': self.dbowner_password,
+                'connection_timeout': 2}
 
     @property
     def allow_update(self):


### PR DESCRIPTION
This PR fixes this old "closed" issue: https://github.com/binxio/cfn-mysql-user-provider/issues/6
To avoid waiting/hanging for a hour till cloudformation stops the update/delete itself.
 
In cloudformation, you will get this output
<span>

<span>

2022-05-11 17:49:59 UTC+0200 | MySQLUserTest |  CREATE_FAILED | Received response status [FAILED] from custom resource. Message returned: Failed to create user, "Error while connecting to MySQL 2003: Can't connect to MySQL server on '$db-endpoint:$db-port' (timed out) ...
-- | -- | -- | -- |


</span>

</span>

This will then trigger a ROLLBACK_IN_PROGRESS and then ROLLBACK_COMPLETE, all under 1 minute.