### PR TITLE
Add Grant support to be defined in MySQLUser

### DIFF
--- a/cloudformation/demo-stack.yaml
+++ b/cloudformation/demo-stack.yaml
@@ -92,6 +92,10 @@ Resources:
       - KongReaderPassword
     Properties:
       User: kongreader
+      Grant:
+      - 'SELECT'
+      GrantOn: 'root.*'
+      WithGrantOption: false
       WithDatabase: false
       PasswordParameterName: !Sub '/${AWS::StackName}/mysql/kongreader/PGPASSWORD'
       Database:

--- a/docs/MySQLUser.md
+++ b/docs/MySQLUser.md
@@ -9,6 +9,9 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Type: Custom::MySQLUser
 Properties:
   User: STRING
+  Grant: [STRING]
+  GrantOn: STRING
+  WithGrantOption: true|false
   Password: STRING
   PasswordParameterName: STRING
   PasswordSecretName: STRING
@@ -40,6 +43,9 @@ For MySQL versions below 5.7, the provider locks the user out be generating a ra
 You can specify the following properties:
 
 - `User` - to create
+- `Grant` - the privileges to grant
+- `GrantOn` - the privilege level to grant, use . for global grants. Update requires replacement.
+- `WithGrantOption` - if the user is allowed to grant others, defaults to false
 - `Password` - of the user 
 - `PasswordParameterName` - name of the ssm parameter containing the password of the user
 - `PasswordSecretName` - friendly name or the ARN of the secret in secrets manager containing the password of the user

--- a/src/mysql_user_provider.py
+++ b/src/mysql_user_provider.py
@@ -253,9 +253,9 @@ class MySQLUser(ResourceProvider):
     @property
     def url(self):
         if self.with_database:
-            return 'mysql:%s:%s:%s:%s:%s:%s' % (self.host, self.port, self.dbname, self.mysql_user(self.user), self.user, self.grant_on)
+            return 'mysql:%s:%s:%s:%s:%s' % (self.host, self.port, self.dbname, self.mysql_user(self.user), self.user)
         else:
-            return 'mysql:%s:%s:%s::%s:%s' % (self.host, self.port, self.dbname, self.user, self.grant_on)
+            return 'mysql:%s:%s:%s::%s' % (self.host, self.port, self.dbname, self.user)
 
     def connect(self):
         log.info('connecting to database %s on port %d as user %s', self.host, self.port, self.dbowner)
@@ -434,9 +434,10 @@ class MySQLUser(ResourceProvider):
 
     def update(self):
         if (self.dbname != self.dbname_old or
-            self.user != self.user_old or
-            self.grant_on != self.grant_on_old):
+            self.user != self.user_old):
             # Major change, recreate..
+            # Triggers a DELETE of the old resource
+            # after creation of the new is complete
             return self.create()
 
         if (self.grant_on == self.grant_on_old and


### PR DESCRIPTION
Hello,

this PR adds grant support inside `Custom::MySQLUser` and 3 additional properties: 
```
- `Grant` - the privileges to grant
- `GrantOn` - the privilege level to grant, use . for global grants. Update requires replacement.
- `WithGrantOption` - if the user is allowed to grant others, defaults to false
```

As seen from the `demo-stack.yaml`:
```
      Grant:
      - 'SELECT'
      GrantOn: 'root.*'
      WithGrantOption: false
```
